### PR TITLE
Insert trip ideas in reverse chronological order

### DIFF
--- a/routes/v1/trips.js
+++ b/routes/v1/trips.js
@@ -273,7 +273,7 @@ function createTripIdea(params, trip) {
     }
   });
 
-  trip.ideas.push(newParams);
+  trip.ideas.unshift(newParams);
   return trip;
 }
 
@@ -579,7 +579,7 @@ function deleteTripEntry(dayId, entryId, ignoreIdeaCreate, trip) {
 
   if (!ignoreIdeaCreate) {
     var newParams = populateNewParams(entry);
-    trip.ideas.push(newParams);
+    trip.ideas.unshift(newParams);
   }
 
   return trip;


### PR DESCRIPTION
The newest ideas should be at the top of the array. This way, there's no
need to sort the ideas array on the client side each time.

[Finishes #131022959]